### PR TITLE
missing dependency of Crypt::DH::GMP

### DIFF
--- a/cpan-api/Dockerfile
+++ b/cpan-api/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y \
     libcurl4-openssl-dev \
     libexpat1-dev \
     libxml2-dev \
+    libgmp10-dev \
     make
 
 RUN curl -L http://cpanmin.us | perl - App::cpanminus


### PR DESCRIPTION
build image (cd cpan-api; docker build -t cpan-api .) failed, because missing some gmc.h library for module Crypt::DH::GMP (and this is dependency of module Net::OpenID::Common)

```
(...)

! Configure failed for Crypt-DH-GMP-0.00012. See /root/.cpanm/work/1423053241.7/build.log for details.
! Installing the dependencies failed: Module 'Crypt::DH::GMP' is not installed
! Bailing out the installation for Net-OpenID-Common-1.18.
Successfully installed JSON-2.90
! Installing the dependencies failed: Module 'Net::OpenID::Common' is not installed
! Bailing out the installation for Net-OpenID-Consumer-1.15.

(...)

! Installing the dependencies failed: Module 'Test::OpenID::Server' is not installed, Module 'Net::OpenID::Consumer' is not installed
! Bailing out the installation for /cpan-api/.
385 distributions installed
Installing modules failed
2015/02/04 13:41:43 The command [/bin/sh -c carton install] returned a non-zero code: 2
```